### PR TITLE
Fix syntax on enabling cloud_sql_proxy service

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,4 +19,4 @@
 - name: Enable cloud-sql-proxy service
   service:
     name: cloud-sql-proxy.service
-    enabled: true
+    enabled: yes


### PR DESCRIPTION
"enabled" parameter for service module take value "yes" or "no"
https://docs.ansible.com/ansible/latest/modules/service_module.html